### PR TITLE
Iterator changed to IntoIterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_iter" # underscore for consistency with other serde-related crates
-version = "0.1.1"
+version = "0.2.0"
 authors = ["SOFe <sofe2038@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/map.rs
+++ b/src/map.rs
@@ -30,12 +30,13 @@ use serde::ser::{Serialize, SerializeMap, Serializer};
 pub fn serialize<S, T, K, V>(iter: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
-    T: Iterator<Item = (K, V)> + Clone,
+    T: IntoIterator<Item = (K, V)> + Clone,
     K: Serialize,
     V: Serialize,
 {
+    let iter = iter.clone().into_iter();
     let mut map = serializer.serialize_map(Some(iter.size_hint().0))?;
-    for (key, value) in iter.clone() {
+    for (key, value) in iter {
         map.serialize_entry(&key, &value)?;
     }
     map.end()
@@ -51,7 +52,7 @@ mod tests {
     #[derive(Serialize)]
     struct Foo<T>
     where
-        T: Iterator<Item = (&'static str, usize)> + Clone,
+        T: IntoIterator<Item = (&'static str, usize)> + Clone,
     {
         #[serde(with = "super")]
         bar: T,


### PR DESCRIPTION
`IntoIterator` is a more generic version of an iterator, that also
happens to support conversion of `CloneOnce` into the inner iterator
*before* iteration. This way we avoid taking the value out and putting
it back at each call of `next()` and also avoid using `RefCell`.

However, this change is formally backwards-incompatible because
`CloneOnce` ceased to implement `Iterator`, so any code that calls its
methods would break. For the intent of this crate, this should be
unlikely, so upgrading will be trivial in most cases.

There's also a small improvement in the clarity of the panic message.

Closes #1